### PR TITLE
fix: save pdf and image files in tmp folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,8 +293,6 @@ ipython_config.py
 # Remove previous ipynb_checkpoints
 #   git rm -r .ipynb_checkpoints/
 
-
 *.out
 *.pdf
-tmp*
-image*
+tmp/

--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ from src.bot import (
     SLACK_APP_TOKEN,
     respond,
 )
-import datetime
+import uuid
 
 app = App(token=SLACK_BOT_TOKEN)
 TMP_FOLDER_NAME = "tmp"
@@ -67,8 +67,9 @@ def respond_to_mention(event, say):
             print(f"Failed to make tmp folder: {e}")
 
     for url_dic in url_list:
-        prefix = str(datetime.datetime.now()).strip()
-        tmp_pdf_file_name = f'tmp_{prefix}_{os.path.basename(url_dic["url"])}'
+        tmp_pdf_file_name = (
+            f'paper_{str(uuid.uuid4())}_{os.path.basename(url_dic["url"])}'
+        )
         pdf_save_path = os.path.join(TMP_FOLDER_NAME, tmp_pdf_file_name)
         respond(
             say,

--- a/src/paper.py
+++ b/src/paper.py
@@ -14,7 +14,7 @@ def _is_pdf(tmp_file_name, http_response_obj):
     return "application/pdf" in content_type or "application/pdf" in mimetype
 
 
-def download_pdf(url_dic, tmp_file_name, slack_bot_token):
+def download_pdf(url_dic, save_path, slack_bot_token):
     req = urllib.request.Request(url_dic["url"])
     if url_dic["is_slack_upload"]:
         req.add_header("Authorization", f"Bearer {slack_bot_token}")
@@ -22,12 +22,12 @@ def download_pdf(url_dic, tmp_file_name, slack_bot_token):
     logger.info(f'Downloading pdf from {url_dic["url"]}...')
     try:
         with urllib.request.urlopen(req) as web_file:
-            with open(tmp_file_name, "wb") as local_file:
+            with open(save_path, "wb") as local_file:
                 local_file.write(web_file.read())
 
-            if not _is_pdf(tmp_file_name, web_file):
+            if not _is_pdf(save_path, web_file):
                 logger.warn(f'Content-type of {url_dic["url"]} is not application/pdf.')
-                os.remove(tmp_file_name)
+                os.remove(save_path)
                 return False
     except Exception as e:
         logger.warning(f'Failed to download pdf from {url_dic["url"]}.')
@@ -80,6 +80,7 @@ def _recoverpix(doc, item):
 
 
 def _extract_images(
+    tmp_folder_name,
     doc,
     min_width=600,
     min_height=600,
@@ -116,24 +117,24 @@ def _extract_images(
                 continue
             suffix = str(datetime.datetime.now()).strip()
             imgname = f'image{pno + 1}_{suffix}.{image["ext"]}'
-            images.append(imgname)
-            imgfile = os.path.join(imgname)
-            fout = open(imgfile, "wb")
+            image_save_path = os.path.join(tmp_folder_name, imgname)
+            fout = open(image_save_path, "wb")
             fout.write(imgdata)
             fout.close()
+            images.append(image_save_path)
             xreflist.append(xref)
 
     logger.info(f"Successfully extract {len(xreflist)} images.")
     return images
 
 
-def read(tmp_file_name):
+def read(tmp_folder_name, tmp_file_name):
     logger.info(f"Reading pdf text from {tmp_file_name}...")
     paper_text = ""
     paper_images = []
     with fitz.open(tmp_file_name) as doc:
         paper_text = "".join([page.get_text() for page in doc]).strip()
-        paper_images = _extract_images(doc)
+        paper_images = _extract_images(tmp_folder_name, doc)
 
     # delete after refenrences
     reference_pos = max(

--- a/src/paper.py
+++ b/src/paper.py
@@ -118,9 +118,8 @@ def _extract_images(
             suffix = str(datetime.datetime.now()).strip()
             imgname = f'image{pno + 1}_{suffix}.{image["ext"]}'
             image_save_path = os.path.join(tmp_folder_name, imgname)
-            fout = open(image_save_path, "wb")
-            fout.write(imgdata)
-            fout.close()
+            with open(image_save_path, "wb") as fout:
+                fout.write(imgdata)
             images.append(image_save_path)
             xreflist.append(xref)
 

--- a/src/paper.py
+++ b/src/paper.py
@@ -3,7 +3,7 @@ import urllib.request
 from logzero import logger
 import fitz
 import mimetypes
-import datetime
+import uuid
 
 
 def _is_pdf(tmp_file_name, http_response_obj):
@@ -115,8 +115,7 @@ def _extract_images(
 
             if width / height > max_ratio or height / width > max_ratio:
                 continue
-            suffix = str(datetime.datetime.now()).strip()
-            imgname = f'image{pno + 1}_{suffix}.{image["ext"]}'
+            imgname = f'image{pno + 1}_{str(uuid.uuid4())}.{image["ext"]}'
             image_save_path = os.path.join(tmp_folder_name, imgname)
             with open(image_save_path, "wb") as fout:
                 fout.write(imgdata)

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,10 +10,10 @@ def load_env():
     load_dotenv(dotenv_path)
 
 
-def remove_tmp_files(pdf_file, images):
+def remove_tmp_files(pdf_file_path, image_file_paths):
     try:
-        os.remove(pdf_file)
-        for image in images:
+        os.remove(pdf_file_path)
+        for image in image_file_paths:
             os.remove(image)
     except OSError as e:
         logger.error(f"Failed to remove file: {e}")


### PR DESCRIPTION
#24 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - PDFファイルを一時フォルダに保存する機能を追加しました。
  - 保存された画像のパスを管理する新しい方法を導入しました。

- **バグ修正**
  - `.gitignore`の設定を更新し、一時ファイルのバージョン管理を改善しました。

- **リファクタリング**
  - PDFのダウンロードと画像の抽出機能を改善し、一時フォルダの使用を最適化しました。

- **その他の変更**
  - 一時ファイルを削除する関数を更新し、より正確にファイルパスを扱うようにしました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->