### PR TITLE
fix: set image max_num

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,7 +16,7 @@ from src.bot import (
 import uuid
 
 app = App(token=SLACK_BOT_TOKEN)
-TMP_FOLDER_NAME = "tmp"
+TMP_FOLDER_NAME = "data"
 
 
 @app.event("message")
@@ -106,13 +106,16 @@ def respond_to_mention(event, say):
             thread_id,
             text="論文中の図表です。\n（うまく切り出せない場合もあります:man-bowing:）",
         )
-        respond(
-            say,
-            user_id,
-            channel_id,
-            thread_id,
-            blocks=build_image_blocks(image_save_paths, channel_id, thread_id),
-        )
+        try:
+            respond(
+                say,
+                user_id,
+                channel_id,
+                thread_id,
+                blocks=build_image_blocks(image_save_paths, channel_id, thread_id),
+            )
+        except Exception as e:
+            logger.warning(f"Exception: {e}")
     remove_tmp_files(pdf_save_path, image_save_paths)
     logger.info("Successfully send response.")
 

--- a/src/paper.py
+++ b/src/paper.py
@@ -94,12 +94,16 @@ def _extract_images(
     imglist = []
     images = []
     logger.info("Extracting images...")
+    is_max_num = False
     for pno in range(page_count):
-        if len(images) >= max_num:
+        if is_max_num:
             break
         il = doc.get_page_images(pno)
         imglist.extend([x[0] for x in il])
         for img in il:
+            if len(images) >= max_num:
+                is_max_num = True
+                break
             xref = img[0]
             if xref in xreflist:
                 continue


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- メンションに応答する際の例外を処理するためのtry-exceptブロックを追加しました。保存されたパスに基づいて画像ブロックを送信します。
- **改善点**
	- 一時フォルダの名前を "tmp" から "data" に更新しました。
	- 画像処理プロセスを最適化するために、処理された画像の数に基づいてループ終了を制御する新しいbooleanフラグ `is_max_num` を導入しました。最大画像数に達した場合に早期に終了します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->